### PR TITLE
socket error after reconnection

### DIFF
--- a/RAPID/SERVER.mod
+++ b/RAPID/SERVER.mod
@@ -461,7 +461,7 @@ ERROR (LONG_JMP_ALL_ERR)
             SocketClose serverSocket;
             !//Reinitiate the server
             ServerCreateAndConnect ipController,serverPort;
-            reconnected:= TRUE;
+            reconnected:= FALSE;
             connected:= TRUE;
             RETRY; 
         DEFAULT:
@@ -474,7 +474,7 @@ ERROR (LONG_JMP_ALL_ERR)
             SocketClose serverSocket;
             !//Reinitiate the server
             ServerCreateAndConnect ipController,serverPort;
-            reconnected:= TRUE;
+            reconnected:= FALSE;
             connected:= TRUE;
             RETRY;
     ENDTEST


### PR DESCRIPTION
The parameter reconnected in lines 464 and 477 of server.mod must be

reconnected = FALSE;

Otherwise the first command after a reconnection doesn't return any message and abb.py keep waiting for it forever.